### PR TITLE
Add MANIFEST.in with package include rules

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,18 @@
+include MANIFEST.in
+include requirements.txt
+include *.json
+include *.md
+include *.py
+include *.txt
+recursive-include erpnext_law_ui *.css
+recursive-include erpnext_law_ui *.csv
+recursive-include erpnext_law_ui *.html
+recursive-include erpnext_law_ui *.ico
+recursive-include erpnext_law_ui *.js
+recursive-include erpnext_law_ui *.json
+recursive-include erpnext_law_ui *.md
+recursive-include erpnext_law_ui *.png
+recursive-include erpnext_law_ui *.py
+recursive-include erpnext_law_ui *.svg
+recursive-include erpnext_law_ui *.txt
+recursive-exclude erpnext_law_ui *.pyc


### PR DESCRIPTION
### Motivation
- Ensure UI app assets and repository metadata are included in source distributions by adding a packaging manifest file `MANIFEST.in`.
- Avoid missing frontend files (CSS/JS/HTML/images) and common repo files when building sdist or otherwise packaging the app.

### Description
- Add `MANIFEST.in` at the repository root with root `include` patterns (`requirements.txt`, `*.json`, `*.md`, `*.py`, `*.txt`) and `recursive-include` rules for `erpnext_law_ui` assets (`*.css`, `*.js`, `*.html`, `*.png`, `*.svg`, `*.py`, etc.).
- Add `recursive-exclude erpnext_law_ui *.pyc` to exclude compiled Python files from the package.

### Testing
- Verified the new file contents with `nl -ba MANIFEST.in`, which displayed the expected include/exclude rules.
- Added and committed the file to the repository and confirmed the commit completed successfully; no separate automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68b5112608323bdb7baa0dda6ff20)