### PR TITLE
Unify black-gold branding and splash assets for erpnext_law_ui

### DIFF
--- a/erpnext_law_ui/hooks.py
+++ b/erpnext_law_ui/hooks.py
@@ -4,6 +4,8 @@ app_publisher = "Al-Hadi Software Co."
 app_description = "نظام احترافي لإدارة القضايا والموكلين"
 app_email = "haider@alhadi.co"
 app_license = "mit"
+app_logo_url = "/assets/erpnext_law_ui/images/law_logo.svg"
+splash_screen_logo = "/assets/erpnext_law_ui/images/law_logo.svg"
 app_favicon = "/assets/erpnext_law_ui/images/law_favicon.svg"
 
 # Apps
@@ -264,6 +266,6 @@ website_context = {
 }
 
 user_navbar_items = [
+    {"label": "موقع شركة الهادي", "target": "https://al-hadi.co", "standard": 1},
     {"label": "دعم شركة الهادي", "target": "https://al-hadi.co/support", "standard": 1},
-    {"label": "عن النظام", "route": "/law-about", "standard": 1}
 ]

--- a/erpnext_law_ui/public/css/desk_custom.css
+++ b/erpnext_law_ui/public/css/desk_custom.css
@@ -1,6 +1,36 @@
-.navbar {
+/* فرض اللون الأسود والذهبي على الناف بار في كل الصفحات */
+.navbar,
+.header-navbar,
+.navbar-default {
     background-color: #111 !important;
     border-bottom: 2px solid #d4af37 !important;
+}
+
+/* توحيد ألوان النصوص والأيقونات في الناف بار */
+.navbar .navbar-nav > li > a,
+.navbar .breadcrumb-item a,
+.navbar .breadcrumb-item::before {
+    color: #d4af37 !important;
+}
+
+/* إخفاء روابط Frappe و About و Support بشكل قاطع */
+/* استهداف القائمة المنسدلة في الناف بار وفي القائمة الجانبية (Sidebar) */
+[data-label="Frappe Support"],
+[data-label="About"],
+[data-label="Documentation"],
+[data-label="System Health"],
+.dropdown-menu [data-label="About"],
+.sidebar-menu-item [data-label="About"] {
+    display: none !important;
+}
+
+/* تخصيص شاشة التحميل (Preloader) */
+#loading-screen {
+    background-color: #111 !important;
+}
+
+#loading-screen img {
+    filter: drop-shadow(0 0 8px #d4af37);
 }
 
 .btn-primary {
@@ -22,10 +52,4 @@
     border: 1px solid #d4af37 !important;
     border-radius: 10px !important;
     overflow: hidden;
-}
-
-li[data-label="Frappe Support"],
-li[data-label="About"],
-li[data-label="Documentation"] {
-    display: none !important;
 }

--- a/erpnext_law_ui/public/images/law_logo.svg
+++ b/erpnext_law_ui/public/images/law_logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320" role="img" aria-label="Al-Hadi Law Logo">
+  <rect width="320" height="320" rx="40" fill="#111111"/>
+  <g fill="none" stroke="#d4af37" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M70 235h180"/>
+    <path d="M98 236V118l62-38 62 38v118"/>
+    <path d="M134 130h52"/>
+    <path d="M160 130v106"/>
+    <path d="M118 168h84"/>
+  </g>
+  <text x="160" y="282" text-anchor="middle" fill="#d4af37" font-family="Arial, sans-serif" font-size="24" font-weight="700">AL-HADI LAW</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Ensure a consistent black-and-gold visual identity across Desk, List and Form pages and unify the app/splash branding assets.
- Remove default Frappe/About/Support links from the UI and surface only Al‑Hadi branded navigation items.

### Description
- Added explicit branding hooks in `erpnext_law_ui/hooks.py` including `app_logo_url`, `splash_screen_logo`, and kept `app_favicon` all pointing to `/assets/erpnext_law_ui/images/*.svg`.
- Restricted `user_navbar_items` in `hooks.py` to Al‑Hadi custom links only (`https://al-hadi.co` and `/support`).
- Rewrote `erpnext_law_ui/public/css/desk_custom.css` to target `.navbar`, `.header-navbar`, and `.navbar-default`, unify text/icon colors to gold, hard-hide `Frappe Support`/`About`/`Documentation`/`System Health` entries, and add preloader background and logo glow styling.
- Added new branding asset `erpnext_law_ui/public/images/law_logo.svg` for use as app logo and splash screen logo.

### Testing
- Ran `python -m py_compile erpnext_law_ui/hooks.py` which completed successfully.
- Captured a browser screenshot via Playwright (artifact produced) for a visual check, noting the local app server at `http://127.0.0.1:8000` was not running in this environment so the live app could not be fully validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e8efa5148323913448ee4331e963)